### PR TITLE
fix: New lines in failed email logging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,9 @@ dotenv.config();
     const status = await sendEmail(configuration, targetEmail, body);
     if (!status) {
       failedBar.increment();
-      failureStream.write(`${targetEmail.email},${targetEmail.unsubscribeId}`);
+      failureStream.write(
+        `${targetEmail.email},${targetEmail.unsubscribeId}\n`
+      );
     } else {
       sentBar.increment();
     }


### PR DESCRIPTION
Signed-off-by: nhcarrigan <nhcarrigan@gmail.com>

# Pull Request

<!--Before contributing, please read our contributing guidelines-->

## Description:

Adds line-breaks to the failed email logging to properly parse the emails into a usable `.csv` file.

<!--A brief description of what your pull request does.--> 

## Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #XXXXX
