### PR TITLE
feat: Fetch blocked

### DIFF
--- a/docs/cli-steps.md
+++ b/docs/cli-steps.md
@@ -8,13 +8,21 @@ The tool will begin by validating your environment variables. If you are missing
 
 ![env validation](./validation.png)
 
+## Fetch Emails
+
+The tool will prompt you to fetch the emails from the database. If you choose yes, it will connect to the database and pull all emails using the `scripts/fetch.ts` script. If you decline, it will move on.
+
+## Fetch Suppressed
+
+The tool will prompt you to fetch the suppressions (bounced emails, blocked emails, and spam reports) through the SendGrid API. If you choose yes, the tool will query those three endpoints. If you choose no, the tool will move on.
+
 ## Reading the Body
 
 Within your `emailBody.txt` should be the full contents of the email you want to send. The tool will attempt to read that file. If there are any errors, the tool will log a failure message and terminate the process.
 
 ## Test Email
 
-You will be prompted to send a test email. If you choose `N`, the tool will move on to the next step. 
+You will be prompted to send a test email. If you choose `N`, the tool will move on to the next step.
 
 ```diff
 - NOTE: Skipping the test email is NOT recommended.
@@ -26,7 +34,7 @@ If you choose `Y`, you will be prompted to provide an email address to send a te
 
 ## Bounced Emails
 
-If you confirmed that the test email was correct (or skipped the test email), the tool reads the `bouncedEmails.csv` file to check if you have documented any bouncing email addresses. If there is an error with parsing the file, the tool will log a failure message and exit the process. If the list is empty, the tool will prompt you to confirm that list *should* be empty. Answering `N` here will terminate the process so you can confirm the contents of your file.
+If you confirmed that the test email was correct (or skipped the test email), the tool reads the `bouncedEmails.csv` file to check if you have documented any bouncing email addresses. If there is an error with parsing the file, the tool will log a failure message and exit the process. If the list is empty, the tool will prompt you to confirm that list _should_ be empty. Answering `N` here will terminate the process so you can confirm the contents of your file.
 
 ![bounce confirmation](./bounced.png)
 

--- a/package.json
+++ b/package.json
@@ -6,8 +6,6 @@
   "scripts": {
     "build": "tsc",
     "db:seed": "node ./prod/scripts/seed.js",
-    "email:suppressed": "node ./prod/scripts/suppressed.js",
-    "email:fetch": "node ./prod/scripts/fetch.js",
     "lint": "eslint ./src/",
     "start": "node ./prod/index.js"
   },

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc",
     "db:seed": "node ./prod/scripts/seed.js",
+    "email:suppressed": "node ./prod/scripts/suppressed.js",
     "email:fetch": "node ./prod/scripts/fetch.js",
     "lint": "eslint ./src/",
     "start": "node ./prod/index.js"
@@ -40,6 +41,7 @@
     "typescript": "^4.1.2"
   },
   "dependencies": {
+    "@sendgrid/client": "^7.4.0",
     "@sendgrid/mail": "^7.4.0",
     "chalk": "^4.1.0",
     "cli-progress": "^3.8.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ import { getBounced } from "./modules/getBounced";
 import { getEnv } from "./modules/getEnv";
 import { getValid } from "./modules/getValid";
 import { sendEmail } from "./modules/sendEmail";
+import { fetchDatabaseEmails } from "./scripts/fetch";
+import { fetchSuppressedEmails } from "./scripts/suppressed";
 import { barFormatter } from "./tools/barFormatter";
 dotenv.config();
 
@@ -31,6 +33,39 @@ dotenv.config();
    * Set the SendGrid API key
    */
   setApiKey(configuration.apiKey);
+
+  /**
+   * Prompt to fetch emails from DB
+   */
+  const getEmailsFromDatabase = await prompt([
+    {
+      name: "confirmed",
+      message: chalk.cyan.bgBlack(
+        "Do you want to fetch the email list from your database?"
+      ),
+      type: "confirm",
+    },
+  ]);
+  if (getEmailsFromDatabase.confirmed) {
+    await fetchDatabaseEmails();
+  }
+
+  /**
+   * Prompt to fetch suppressed emails
+   */
+  const getSuppressedEmails = await prompt([
+    {
+      name: "confirmed",
+      message: chalk.cyan.bgBlack(
+        "Do you want to get the list of suppressed emails from SendGrid?"
+      ),
+      type: "confirm",
+    },
+  ]);
+
+  if (getSuppressedEmails.confirmed) {
+    await fetchSuppressedEmails();
+  }
 
   /**
    * Get the body of the email

--- a/src/interfaces/suppressedInt.ts
+++ b/src/interfaces/suppressedInt.ts
@@ -1,0 +1,19 @@
+export interface blockInt {
+  created: number;
+  email: string;
+  reason: string;
+  status: string;
+}
+
+export interface bounceInt {
+  created: number;
+  email: string;
+  reason: string;
+  status: string;
+}
+
+export interface spamInt {
+  created: number;
+  email: string;
+  ip: string;
+}

--- a/src/scripts/fetch.ts
+++ b/src/scripts/fetch.ts
@@ -12,94 +12,115 @@ import validator from "validator";
 import { validate } from "email-validator";
 import { MongoClient } from "mongodb";
 import ora from "ora";
+import chalk from "chalk";
 
-const filePath = path.join(__dirname + "/../validEmails.csv");
-const invalidFilePath = path.join(__dirname + "/../invalidEmails.csv");
+export const fetchDatabaseEmails = async (): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const filePath = path.join(__dirname + "/../validEmails.csv");
+    const invalidFilePath = path.join(__dirname + "/../invalidEmails.csv");
 
-const validOutput = createWriteStream(filePath, { encoding: "utf8" });
-const invalidOutput = createWriteStream(invalidFilePath, {
-  encoding: "utf8",
-});
+    const validOutput = createWriteStream(filePath, { encoding: "utf8" });
+    const invalidOutput = createWriteStream(invalidFilePath, {
+      encoding: "utf8",
+    });
 
-validOutput.write("email,unsubscribeId\n");
-invalidOutput.write("email,unsubscribeId\n");
+    validOutput.write("email,unsubscribeId\n");
+    invalidOutput.write("email,unsubscribeId\n");
 
-const rs = new Stream.Readable({ objectMode: true });
-//rs._read = function () {};
-
-rs.on("data", ({ email, unsubscribeId }) => {
-  if (validator.isEmail(email)) {
-    validOutput.write(`${email},${unsubscribeId}\n`);
-  } else if (validate(email)) {
-    validOutput.write(`${email},${unsubscribeId}\n`);
-  } else {
-    invalidOutput.write(`${email},${unsubscribeId}\n`);
-  }
-});
-
-const { MONGO_DB, MONGO_URI, MONGO_USER, MONGO_PASSWORD } = process.env;
-
-if (!MONGO_DB || !MONGO_URI || !MONGO_USER || !MONGO_PASSWORD) {
-  console.error("Missing required environment variables.");
-  process.exit(1);
-}
-
-MongoClient.connect(
-  MONGO_URI,
-  {
-    useNewUrlParser: true,
-    useUnifiedTopology: true,
-    auth: { user: MONGO_USER, password: MONGO_PASSWORD },
-    poolSize: 20,
-  },
-  (err, client) => {
-    if (err) {
-      console.error(err);
+    const rs = new Stream.Readable({ objectMode: true });
+    rs._read = function () {
       return;
+    };
+
+    rs.on("data", ({ email, unsubscribeId }) => {
+      if (validator.isEmail(email)) {
+        validOutput.write(`${email},${unsubscribeId}\n`);
+      } else if (validate(email)) {
+        validOutput.write(`${email},${unsubscribeId}\n`);
+      } else {
+        invalidOutput.write(`${email},${unsubscribeId}\n`);
+      }
+    });
+
+    const { MONGO_DB, MONGO_URI, MONGO_USER, MONGO_PASSWORD } = process.env;
+
+    if (!MONGO_DB || !MONGO_URI || !MONGO_USER || !MONGO_PASSWORD) {
+      console.error(
+        chalk.red.bgBlack(
+          "Missing required environment variables. Terminating process..."
+        )
+      );
+      reject();
+      process.exit(1);
     }
-    const db = client.db(MONGO_DB);
 
-    const stream = db
-      .collection("user")
-      .find(
-        {
-          $and: [
-            { email: { $exists: true } },
-            { email: { $ne: "" } },
-            { email: { $ne: null } },
-            { email: { $not: /(test|fake)/i } },
-            {
-              $or: [
-                { sendQuincyEmail: true },
-                { sendQuincyEmail: { $exists: false } },
-                { sendQuincyEmail: null },
-              ],
-            },
-          ],
-        },
-        {
-          projection: {
-            email: 1,
-            unsubscribeId: 1,
-          },
-        }
-      )
-      .batchSize(100)
-      .stream();
-
-    const spinner = ora("Begin querying emails...");
+    const spinner = ora(chalk.cyan.bgBlack("Compiling email list..."));
     spinner.start();
 
-    stream.on("data", ({ email, unsubscribeId }) => {
-      const data = { email, unsubscribeId };
-      spinner.text = `Getting info for: ${email}\n`;
-      rs.push(data);
-    });
+    MongoClient.connect(
+      MONGO_URI,
+      {
+        useNewUrlParser: true,
+        useUnifiedTopology: true,
+        auth: { user: MONGO_USER, password: MONGO_PASSWORD },
+        poolSize: 20,
+      },
+      (err, client) => {
+        if (err) {
+          console.error(err);
+          spinner.fail(
+            chalk.red.bgBlack(
+              "Failed to connect to database. Terminating process..."
+            )
+          );
+          process.exit(1);
+        }
+        const db = client.db(MONGO_DB);
 
-    stream.on("end", () => {
-      rs.push(null);
-      client.close();
-      spinner.succeed("Completed compiling mailing list.");
-    });
-  }
-);
+        const stream = db
+          .collection("user")
+          .find(
+            {
+              $and: [
+                { email: { $exists: true } },
+                { email: { $ne: "" } },
+                { email: { $ne: null } },
+                { email: { $not: /(test|fake)/i } },
+                {
+                  $or: [
+                    { sendQuincyEmail: true },
+                    { sendQuincyEmail: { $exists: false } },
+                    { sendQuincyEmail: null },
+                  ],
+                },
+              ],
+            },
+            {
+              projection: {
+                email: 1,
+                unsubscribeId: 1,
+              },
+            }
+          )
+          .batchSize(100)
+          .stream();
+
+        stream.on("data", ({ email, unsubscribeId }) => {
+          const data = { email, unsubscribeId };
+          spinner.text = `Getting info for: ${email}\n`;
+          rs.push(data);
+        });
+
+        stream.on("end", () => {
+          rs.push(null);
+          client.close();
+          spinner.succeed(
+            chalk.green.bgBlack("Completed compiling mailing list.")
+          );
+          resolve();
+          return;
+        });
+      }
+    );
+  });
+};

--- a/src/scripts/suppressed.ts
+++ b/src/scripts/suppressed.ts
@@ -1,0 +1,91 @@
+import { createWriteStream } from "fs-extra";
+import path from "path";
+import client from "@sendgrid/client";
+import { ClientRequest } from "@sendgrid/client/src/request";
+import { config } from "dotenv";
+import { blockInt, bounceInt, spamInt } from "../interfaces/suppressedInt";
+import ora from "ora";
+
+config();
+
+const filePath = path.join(__dirname + "/../bouncedEmails.csv");
+const writeStream = createWriteStream(filePath);
+
+writeStream.write("email\n");
+
+client.setApiKey(process.env.SENDGRID_KEY || "");
+
+const getBlocked = async () => {
+  try {
+    const queryParams = {
+      start_time: 1,
+    };
+    const request: ClientRequest = {
+      qs: queryParams,
+      method: "GET",
+      url: "/v3/suppression/blocks",
+    };
+
+    const [_, body] = await client.request(request);
+
+    body.forEach((object: blockInt) => {
+      writeStream.write(object.email + "\n");
+    });
+  } catch (err) {
+    console.error(err);
+  }
+};
+
+const getBounced = async () => {
+  try {
+    const queryParams = {
+      start_time: 1,
+    };
+    const request: ClientRequest = {
+      qs: queryParams,
+      method: "GET",
+      url: "/v3/suppression/bounces",
+    };
+
+    const [_, body] = await client.request(request);
+
+    body.forEach((object: bounceInt) => {
+      writeStream.write(object.email + "\n");
+    });
+  } catch (err) {
+    console.error(err);
+  }
+};
+
+const getSpam = async () => {
+  try {
+    const queryParams = {
+      start_time: 1,
+    };
+    const request: ClientRequest = {
+      qs: queryParams,
+      method: "GET",
+      url: "/v3/suppression/spam_reports",
+    };
+
+    const [_, body] = await client.request(request);
+
+    body.forEach((object: spamInt) => {
+      writeStream.write(object.email + "\n");
+    });
+  } catch (err) {
+    console.error(err);
+  }
+};
+
+(async () => {
+  const blockedSpinner = ora("Fetching blocked emails...").start();
+  await getBlocked();
+  blockedSpinner.succeed("Blocked emails obtained!");
+  const bouncedSpinner = ora("Fetching bounced emails...").start();
+  await getBounced();
+  bouncedSpinner.succeed("Bounced emails obtained!");
+  const spamSpinner = ora("Fetching spam reports...").start();
+  await getSpam();
+  spamSpinner.succeed("Spam reports obtained!");
+})();

--- a/src/scripts/suppressed.ts
+++ b/src/scripts/suppressed.ts
@@ -5,6 +5,7 @@ import { ClientRequest } from "@sendgrid/client/src/request";
 import { config } from "dotenv";
 import { blockInt, bounceInt, spamInt } from "../interfaces/suppressedInt";
 import ora from "ora";
+import chalk from "chalk";
 
 config();
 
@@ -33,6 +34,10 @@ const getBlocked = async () => {
     });
   } catch (err) {
     console.error(err);
+    console.error(
+      chalk.red.bgBlack("Failed to get blocked emails. Terminating process.")
+    );
+    process.exit(1);
   }
 };
 
@@ -54,6 +59,10 @@ const getBounced = async () => {
     });
   } catch (err) {
     console.error(err);
+    console.error(
+      chalk.red.bgBlack("Failed to get bounced emails. Terminating process.")
+    );
+    process.exit(1);
   }
 };
 
@@ -75,17 +84,29 @@ const getSpam = async () => {
     });
   } catch (err) {
     console.error(err);
+    console.error(
+      chalk.red.bgBlack(
+        "Failed to get spam report emails. Terminating process."
+      )
+    );
+    process.exit(1);
   }
 };
 
-(async () => {
-  const blockedSpinner = ora("Fetching blocked emails...").start();
+export const fetchSuppressedEmails = async (): Promise<void> => {
+  const blockedSpinner = ora(
+    chalk.cyan.bgBlack("Fetching blocked emails...")
+  ).start();
   await getBlocked();
-  blockedSpinner.succeed("Blocked emails obtained!");
-  const bouncedSpinner = ora("Fetching bounced emails...").start();
+  blockedSpinner.succeed(chalk.green.bgBlack("Blocked emails obtained!"));
+  const bouncedSpinner = ora(
+    chalk.cyan.bgBlack("Fetching bounced emails...")
+  ).start();
   await getBounced();
-  bouncedSpinner.succeed("Bounced emails obtained!");
-  const spamSpinner = ora("Fetching spam reports...").start();
+  bouncedSpinner.succeed(chalk.green.bgBlack("Bounced emails obtained!"));
+  const spamSpinner = ora(
+    chalk.cyan.bgBlack("Fetching spam reports...")
+  ).start();
   await getSpam();
-  spamSpinner.succeed("Spam reports obtained!");
-})();
+  spamSpinner.succeed(chalk.green.bgBlack("Spam reports obtained!"));
+};

--- a/src/scripts/suppressed.ts
+++ b/src/scripts/suppressed.ts
@@ -27,7 +27,16 @@ const getBlocked = async () => {
       url: "/v3/suppression/blocks",
     };
 
-    const [_, body] = await client.request(request);
+    const [response, body] = await client.request(request);
+
+    if (response.statusCode !== 200) {
+      console.error(
+        chalk.red.bgBlack(
+          "API call for blocked emails was rejected. Terminating process."
+        )
+      );
+      process.exit(1);
+    }
 
     body.forEach((object: blockInt) => {
       writeStream.write(object.email + "\n");
@@ -52,7 +61,16 @@ const getBounced = async () => {
       url: "/v3/suppression/bounces",
     };
 
-    const [_, body] = await client.request(request);
+    const [response, body] = await client.request(request);
+
+    if (response.statusCode !== 200) {
+      console.error(
+        chalk.red.bgBlack(
+          "API call for bounced emails was rejected. Terminating process."
+        )
+      );
+      process.exit(1);
+    }
 
     body.forEach((object: bounceInt) => {
       writeStream.write(object.email + "\n");
@@ -77,7 +95,16 @@ const getSpam = async () => {
       url: "/v3/suppression/spam_reports",
     };
 
-    const [_, body] = await client.request(request);
+    const [response, body] = await client.request(request);
+
+    if (response.statusCode !== 200) {
+      console.error(
+        chalk.red.bgBlack(
+          "API call for spam reports was rejected. Terminating process."
+        )
+      );
+      process.exit(1);
+    }
 
     body.forEach((object: spamInt) => {
       writeStream.write(object.email + "\n");


### PR DESCRIPTION
# Pull Request

<!--Before contributing, please read our contributing guidelines-->

## Description:

- Adds a script to fetch suppressed emails (blocked, bounced, and spam) from SendGrid API.
- Hacks existing database fetch script into asynchronous call
- Integrates both into CLI wizard
- Heavy error handling through `process.exit()`.

<!--A brief description of what your pull request does.--> 

## Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #XXXXX
