### PR TITLE
fix: paginate API calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sendgrid-experiment",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sendgrid-experiment",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sendgrid/client": "^7.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sendgrid-experiment",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A quick experiment with the SendGrid API",
   "main": "./prod/main.js",
   "scripts": {


### PR DESCRIPTION
# Pull Request

<!--Before contributing, please read our contributing guidelines-->

## Description:

The API routes are paginated, so this PR adds logic to handle the pagination correctly. This will resolve the issue where we were only fetching the first 500 records.
<!--A brief description of what your pull request does.--> 

## Related Issue:

<!--Is this related to an issue? Does it close one? If so, replace the XXXXX below with the issue number.-->

Closes #XXXXX
